### PR TITLE
Remove use of hard coded secret

### DIFF
--- a/config/environments/all.js
+++ b/config/environments/all.js
@@ -55,7 +55,7 @@ module.exports = function () {
 	this.use(cookieParser());
 	this.use(methodOverride());
 	this.use(cookieSession({
-		secret: 'secret',
+		secret: process.env['GAMERPOLLS_COOKIE_SECRET'],
 		store: new MongoStore({
 			url: nconf.get('MONGO_DB')
 		})


### PR DESCRIPTION
**Description**
This pull request fixes a security issue by removing the hard coded cookie secret. This change will instead make the application fetch it from the environment variable `GAMERPOLLS_COOKIE_SECRET`.

By using a hard coded secret, a would-be attacker could manipulate the cookie data and re-sign it using the same cookie secret - potentially leading to an authentication bypass and privilege escalation.

**Vulnerability Classification**
CWE-259: Use of Hard-coded Password
CWE-302: Authentication Bypass by Assumed-Immutable Data

**CVE-ID**
[CVE-2018-10966](https://www.cvedetails.com/cve/CVE-2018-10966/)

**CVSS v3 Score**
6.5 (Medium)

**CVSS v3 Vector**
[AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N)
